### PR TITLE
Fix _packNedb hanging

### DIFF
--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -550,8 +550,7 @@ export function getCommand() {
         // Compact the database
         db.stopAutocompaction();
         await new Promise(resolve => {
-            db.once("compaction.done", resolve);
-            db.compactDatafile();
+            db.compactDatafile(resolve);
         });
     }
 


### PR DESCRIPTION
When using compactDatafile on the root db object, nedb-promises the method takes an undocumented callback. It never emits a "compaction.done" event.