### PR TITLE
Fix misplaced spread operators that cause NEDB operations to throw a TypeError

### DIFF
--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -365,13 +365,13 @@ export function getCommand() {
         if (!fs.existsSync(outputDir)) {
             fs.mkdirSync(outputDir, {recursive: true});
         }
-
+        
         // Load package manifests
         let documentType = "Unknown";
-
+        
         const knownWorldTypes = [ "actors", "cards", "combats", "drawings", "fog", "folders", "items",
         "journal", "macros", "messages", "playlists", "scenes", "tables" ];
-
+        
         if ( knownWorldTypes.includes(compendiumName) ) {
             documentType = compendiumName;
         }
@@ -385,7 +385,7 @@ export function getCommand() {
                 documentType = pack.type ?? pack.entity;
             }
         }
-
+        
         // Iterate over all entries in the db, writing them as individual YAML files
         const docs = await db.find({});
         for (const doc of docs) {
@@ -480,7 +480,7 @@ export function getCommand() {
             console.error(chalk.red(`The pack "${chalk.blue(packDir)}" is currently in use by Foundry VTT. Please close Foundry VTT and try again.`));
             return;
         }
-
+        
         // Create packDir if it doesn't exist already
         if (!fs.existsSync(packDir)) {
             fs.mkdirSync(packDir, {recursive: true});

--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -257,7 +257,7 @@ export function getCommand() {
             }
         }
 
-        game.packages = [...game.modules, ...game.systems, ...game.worlds];
+        game.packages = new Map([...game.modules, ...game.systems, ...game.worlds]);
 
         return game;
     }
@@ -365,27 +365,27 @@ export function getCommand() {
         if (!fs.existsSync(outputDir)) {
             fs.mkdirSync(outputDir, {recursive: true});
         }
-        
+
         // Load package manifests
         let documentType = "Unknown";
-        
+
         const knownWorldTypes = [ "actors", "cards", "combats", "drawings", "fog", "folders", "items",
         "journal", "macros", "messages", "playlists", "scenes", "tables" ];
-        
+
         if ( knownWorldTypes.includes(compendiumName) ) {
             documentType = compendiumName;
         }
         else {
             const game = discoverPackageDirectory(argv);
             // Get all packs from world, system, and modules
-            const packs = [...game.modules, ...game.systems, ...game.worlds].map(p => p.packs).flat();
+            const packs = Object.values(game.packages).map(p => p.packs).flat();
             // Find the pack with the matching name
             const pack = packs.find(p => p.name === compendiumName);
             if ( pack ) {
                 documentType = pack.type ?? pack.entity;
             }
         }
-        
+
         // Iterate over all entries in the db, writing them as individual YAML files
         const docs = await db.find({});
         for (const doc of docs) {
@@ -480,7 +480,7 @@ export function getCommand() {
             console.error(chalk.red(`The pack "${chalk.blue(packDir)}" is currently in use by Foundry VTT. Please close Foundry VTT and try again.`));
             return;
         }
-        
+
         // Create packDir if it doesn't exist already
         if (!fs.existsSync(packDir)) {
             fs.mkdirSync(packDir, {recursive: true});

--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -378,7 +378,7 @@ export function getCommand() {
         else {
             const game = discoverPackageDirectory(argv);
             // Get all packs from world, system, and modules
-            const packs = Object.values(game.packages).map(p => p.packs).flat();
+            const packs = Object.values(game.packages).flatMap(p => p.packs);
             // Find the pack with the matching name
             const pack = packs.find(p => p.name === compendiumName);
             if ( pack ) {


### PR DESCRIPTION
Resolves #23 

This was due to some spread operators being used on `Map<string, object>` to set values that later code uses like an `Iterable<object>`. But `Map<string, object>` is actually `Iterable<[string, object]>`, so the CLI was attempting to read `Array#name`.

Would it be useful for me to write a PR that improves the detail of the JSDoc type annotations of this package? In other words -- to get it to the point where a static type check can nip this sort of thing in the bud, even without a build step. (and, I mean, I don't think that would take me much longer than I spent puzzling over this bug :wink: )

EDIT: Oh, whoops, looks like it's addressed in #15 :facepalm: Honestly didn't occur to me to look for a fix for a "showstopper" bug in a PR for a new feature. Might still be of some use if you want to do a bugfix release ahead of the new feature, though?

My question about submitting a PR for deeper JSDoc annotations still stands, regardless :slightly_smiling_face: