### PR TITLE
Allow Cyrillic characters in filenames

### DIFF
--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -182,7 +182,7 @@ export function getCommand() {
      * @returns {string}                The sanitized filename
      */
     function getSafeFilename(filename) {
-        return filename.replace(/[^a-zA-Z0-9]/g, '_');
+        return filename.replace(/[^a-zA-Z0-9а-яА-Я]/g, '_');
     }
 
     /* -------------------------------------------- */


### PR DESCRIPTION
This range of letters is safe on all Windows, Mac and Linux OSes. It would make working with Russian and Ukrainian compendiums much easier.