### PR TITLE
Rename conflicting parameter alias.

### DIFF
--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -48,7 +48,7 @@ export function getCommand() {
             });
 
             yargs.option("inputDirectory", {
-                alias: "id",
+                alias: "in",
                 describe: "The directory to read from, for Pack based Actions.",
                 type: "string"
             });


### PR DESCRIPTION
Fixes https://github.com/foundryvtt/foundryvtt-cli/issues/25.