### PR TITLE
Log more specific errors when a file fails

### DIFF
--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -365,13 +365,13 @@ export function getCommand() {
         if (!fs.existsSync(outputDir)) {
             fs.mkdirSync(outputDir, {recursive: true});
         }
-        
+
         // Load package manifests
         let documentType = "Unknown";
-        
+
         const knownWorldTypes = [ "actors", "cards", "combats", "drawings", "fog", "folders", "items",
         "journal", "macros", "messages", "playlists", "scenes", "tables" ];
-        
+
         if ( knownWorldTypes.includes(compendiumName) ) {
             documentType = compendiumName;
         }
@@ -385,7 +385,7 @@ export function getCommand() {
                 documentType = pack.type ?? pack.entity;
             }
         }
-        
+
         // Iterate over all entries in the db, writing them as individual YAML files
         const docs = await db.find({});
         for (const doc of docs) {
@@ -480,7 +480,7 @@ export function getCommand() {
             console.error(chalk.red(`The pack "${chalk.blue(packDir)}" is currently in use by Foundry VTT. Please close Foundry VTT and try again.`));
             return;
         }
-        
+
         // Create packDir if it doesn't exist already
         if (!fs.existsSync(packDir)) {
             fs.mkdirSync(packDir, {recursive: true});
@@ -539,11 +539,9 @@ export function getCommand() {
                     await db.insert(value);
                     console.log(`Packed ${chalk.blue(value._id)}${chalk.blue(value.name ? ` (${value.name})` : "")}`);
                 }
+            } catch ( error ) {
+                throw new Error(`Failed to parse ${chalk.red(file)}: ${error}`);
             }
-            catch (error) { 
-                throw `Failed to parse ${chalk.red(file)}: ${error}`;
-            }
-            
         }
 
         // Remove any entries which were not updated
@@ -577,7 +575,7 @@ export function getCommand() {
         // Iterate over all YAML files in the input directory, writing them to the db
         const files = fs.readdirSync(inputDir);
         const seenKeys = new Set();
-        for (const file of files) {
+        for ( const file of files ) {
             try {
                 const fileContents = fs.readFileSync(path.join(inputDir, file));
                 const value = file.endsWith(".yml") ? yaml.load(fileContents) : JSON.parse(fileContents);
@@ -586,11 +584,9 @@ export function getCommand() {
                 seenKeys.add(key);
                 batch.put(key, value);
                 console.log(`Packed ${chalk.blue(value._id)}${chalk.blue(value.name ? ` (${value.name})` : "")}`);
+            } catch ( error ) {
+                throw new Error(`Failed to parse ${chalk.red(file)}: ${error}`);
             }
-            catch (error) {
-                throw `Failed to parse ${chalk.red(file)}: ${error}`;
-            }
-           
         }
 
         // Remove any entries in the db that are not in the input directory

--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -519,30 +519,30 @@ export function getCommand() {
         const files = fs.readdirSync(inputDir);
         const seenKeys = new Set();
         for ( const file of files ) {
-			try {
-				const fileContents = fs.readFileSync(path.join(inputDir, file));
-				const value = file.endsWith(".yml") ? yaml.load(fileContents) : JSON.parse(fileContents);
-				const key = value._key;
-				// If the key starts with !folders, we should skip packing it as nedb doesn't support folders
-				if ( key.startsWith("!folders") ) continue;
+            try {
+                const fileContents = fs.readFileSync(path.join(inputDir, file));
+                const value = file.endsWith(".yml") ? yaml.load(fileContents) : JSON.parse(fileContents);
+                const key = value._key;
+                // If the key starts with !folders, we should skip packing it as nedb doesn't support folders
+                if ( key.startsWith("!folders") ) continue;
 
-				delete value._key;
-				seenKeys.add(value._id);
+                delete value._key;
+                seenKeys.add(value._id);
 
-				// If key already exists, update it
-				const existing = await db.findOne({_id: value._id});
-				if ( existing ) {
-					await db.update({_id: key}, value);
-					console.log(`Updated ${chalk.blue(value._id)}${chalk.blue(value.name ? ` (${value.name})` : "")}`);
-				}
-				else {
-					await db.insert(value);
-					console.log(`Packed ${chalk.blue(value._id)}${chalk.blue(value.name ? ` (${value.name})` : "")}`);
-				}
-			}
+                // If key already exists, update it
+                const existing = await db.findOne({_id: value._id});
+                if ( existing ) {
+                    await db.update({_id: key}, value);
+                    console.log(`Updated ${chalk.blue(value._id)}${chalk.blue(value.name ? ` (${value.name})` : "")}`);
+                }
+                else {
+                    await db.insert(value);
+                    console.log(`Packed ${chalk.blue(value._id)}${chalk.blue(value.name ? ` (${value.name})` : "")}`);
+                }
+            }
             catch (error) { 
-				throw `Failed to parse ${chalk.red(file)}: ${error}`;
-			}
+                throw `Failed to parse ${chalk.red(file)}: ${error}`;
+            }
             
         }
 


### PR DESCRIPTION
When packing compendiums, it can be quite a chore to figure out why the process failed. The current behavior doesn't output *which* file failed and also doesn't contain any clues *why* it failed.

This PR changes both, catching and rethrowing errors on the file scope with a more helpful message.