### PR TITLE
Fix path resolution on Windows

### DIFF
--- a/commands/launch.mjs
+++ b/commands/launch.mjs
@@ -1,7 +1,6 @@
 import Config from "../config.mjs";
 import { spawn } from "child_process";
 import path from "path";
-import { normalizePath } from "../utils/utils.mjs";
 
 /**
  * Get the command object for the launch command
@@ -74,7 +73,7 @@ export function getCommand() {
 
       // Launch Foundry VTT
       const foundry = spawn("node", [
-        normalizePath(path.join(installPath, "resources", "app", "main.js")),
+        path.normalize(path.join(installPath, "resources", "app", "main.js")),
         `--dataPath=${dataPath}`,
         `--port=${port}`,
         demo ? "--demo" : "",

--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -5,7 +5,6 @@ import path from "path";
 import fs from "fs";
 import chalk from "chalk";
 import Datastore from "nedb-promises";
-import { normalizePath } from "../utils/utils.mjs";
 
 /**
  * @typedef {"Module"|"System"|"World"} PackageType
@@ -256,7 +255,7 @@ function readPackageManifests(dataPath, type, { verbose=false }={}) {
   const map = new Map();
 
   for ( const file of fs.readdirSync(dir, { withFileTypes: true }) ) {
-    const manifestPath = normalizePath(`${dir}/${file.name}/${typeLC}.json`);
+    const manifestPath = path.normalize(`${dir}/${file.name}/${typeLC}.json`);
     try {
       const data = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
       data.type = type;
@@ -389,7 +388,7 @@ function determinePaths(argv, operation) {
   pack ??= path.join(dataPath, "Data", typeDir, currentPackageId, "packs", compendiumName);
   source ??= path.join(pack, "_source");
   if ( argv.nedb ) pack += ".db";
-  return { source: path.resolve(normalizePath(source)), pack: path.resolve(normalizePath(pack)) };
+  return { source: path.resolve(path.normalize(source)), pack: path.resolve(path.normalize(pack)) };
 }
 
 /* -------------------------------------------- */

--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -386,10 +386,10 @@ function determinePaths(argv, operation) {
 
   let pack = operation === "pack" ? argv.outputDirectory : argv.inputDirectory;
   let source = operation === "pack" ? argv.inputDirectory : argv.outputDirectory;
-  pack ??= path.posix.join(dataPath, "Data", typeDir, currentPackageId, "packs", compendiumName);
-  source ??= path.posix.join(pack, "_source");
+  pack ??= path.join(dataPath, "Data", typeDir, currentPackageId, "packs", compendiumName);
+  source ??= path.join(pack, "_source");
   if ( argv.nedb ) pack += ".db";
-  return { source: path.posix.resolve(normalizePath(source)), pack: path.posix.resolve(normalizePath(pack)) };
+  return { source: path.resolve(normalizePath(source)), pack: path.resolve(normalizePath(pack)) };
 }
 
 /* -------------------------------------------- */
@@ -519,7 +519,7 @@ async function handleUnpack(argv) {
     return;
   }
 
-  if ( !argv.nedb && isFileLocked(path.posix.join(pack, "LOCK")) ) {
+  if ( !argv.nedb && isFileLocked(path.join(pack, "LOCK")) ) {
     console.error(chalk.red(`The pack "${chalk.blue(pack)}" is currently in use by Foundry VTT. `
       + "Please close Foundry VTT and try again."));
     process.exitCode = 1;
@@ -573,10 +573,10 @@ async function unpackNedb(pack, outputDir, argv) {
     await unpackDoc(doc, TYPE_COLLECTION_MAP[documentType]);
     let fileName;
     if ( argv.yaml ) {
-      fileName = path.posix.join(outputDir, `${name}.yml`);
+      fileName = path.join(outputDir, `${name}.yml`);
       fs.writeFileSync(fileName, yaml.dump(doc));
     } else {
-      fileName = path.posix.join(outputDir, `${name}.json`);
+      fileName = path.join(outputDir, `${name}.json`);
       fs.writeFileSync(fileName, JSON.stringify(doc, null, 2) + "\n");
     }
     console.log(`Wrote ${chalk.blue(fileName)}`);
@@ -614,10 +614,10 @@ async function unpackClassicLevel(packDir, outputDir, argv) {
     await unpackDoc(doc, collection);
     let fileName;
     if ( argv.yaml ) {
-      fileName = path.posix.join(outputDir, `${name}.yml`);
+      fileName = path.join(outputDir, `${name}.yml`);
       fs.writeFileSync(fileName, yaml.dump(doc));
     } else {
-      fileName = path.posix.join(outputDir, `${name}.json`);
+      fileName = path.join(outputDir, `${name}.json`);
       fs.writeFileSync(fileName, JSON.stringify(doc, null, 2) + "\n");
     }
     console.log(`Wrote ${chalk.blue(fileName)}`);
@@ -643,7 +643,7 @@ async function handlePack(argv) {
     return;
   }
 
-  if ( !argv.nedb && isFileLocked(path.posix.join(pack, "LOCK")) ) {
+  if ( !argv.nedb && isFileLocked(path.join(pack, "LOCK")) ) {
     console.error(chalk.red(`The pack "${chalk.blue(pack)}" is currently in use by Foundry VTT. `
       + "Please close Foundry VTT and try again."));
     process.exitCode = 1;
@@ -689,7 +689,7 @@ async function packNedb(pack, inputDir) {
   // Iterate over all files in the input directory, writing them to the DB.
   for ( const file of fs.readdirSync(inputDir) ) {
     try {
-      const fileContents = fs.readFileSync(path.posix.join(inputDir, file));
+      const fileContents = fs.readFileSync(path.join(inputDir, file));
       const doc = file.endsWith(".yml") ? yaml.load(fileContents) : JSON.parse(fileContents);
       const key = doc._key;
       const [, collection] = key.split("!");
@@ -735,7 +735,7 @@ async function packClassicLevel(packDir, inputDir) {
   // Iterate over all files in the input directory, writing them to the DB.
   for ( const file of fs.readdirSync(inputDir) ) {
     try {
-      const fileContents = fs.readFileSync(path.posix.join(inputDir, file));
+      const fileContents = fs.readFileSync(path.join(inputDir, file));
       const doc = file.endsWith(".yml") ? yaml.load(fileContents) : JSON.parse(fileContents);
       const [, collection] = doc._key.split("!");
       await packDoc(doc, collection);


### PR DESCRIPTION
- The explicit use of posix paths causes absolute paths to break. Since the paths are previously normalized to absolute paths, it means that nearly all paths break on Windows.
- Remove the custom normalize implementation and use the standard Node.js function instead.