### PR TITLE
Add some better YAML compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Extract the contents of a compendium pack into individual source files for each 
 * **options:** *object*
     * **nedb:** *boolean = false* Whether to operate on a NeDB database, otherwise a LevelDB database is assumed.
     * **yaml:** *boolean = false* Whether the source files in YAML format, otherwise JSON is assumed.
+    * **yamlOptions** *object = {}* Options to pass to `yaml.dump`.
     * **log:** *boolean = false* Whether to log operation progress to the console.
     * **documentType:** *string* For NeDB operations, a **documentType** must be provided. This should be the same as the pack's *type* field in the *module.json* or *system.json*.
     * **transformEntry:** *(entry: object): Promise<false|void>* A function that is called on every entry. Returning *false* indicates that the entry should be discarded.

--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -196,7 +196,9 @@ async function compileNedb(pack, files, { log, transformEntry }={}) {
   for ( const file of files ) {
     try {
       const contents = fs.readFileSync(file, "utf8");
-      const doc = path.extname(file) === ".yml" ? yaml.load(contents) : JSON.parse(contents);
+      const ext = path.extname(file);
+      const isYaml = ext === ".yml" || ext === ".yaml";
+      const doc = isYaml ? yaml.load(contents) : JSON.parse(contents);
       const key = doc._key;
       const [, collection] = key.split("!");
       // If the key starts with !folders, we should skip packing it as NeDB doesn't support folders.
@@ -247,7 +249,9 @@ async function compileClassicLevel(pack, files, { log, transformEntry }={}) {
   for ( const file of files ) {
     try {
       const contents = fs.readFileSync(file, "utf8");
-      const doc = path.extname(file) === ".yml" ? yaml.load(contents) : JSON.parse(contents);
+      const ext = path.extname(file);
+      const isYaml = ext === ".yml" || ext === ".yaml";
+      const doc = isYaml ? yaml.load(contents) : JSON.parse(contents);
       const [, collection] = doc._key.split("!");
       if ( await transformEntry?.(doc) === false ) continue;
       await packDoc(doc, collection);
@@ -462,7 +466,7 @@ function findSourceFiles(root, { yaml=false, recursive=false }={}) {
     }
     if ( !entry.isFile() ) continue;
     const ext = path.extname(name);
-    if ( yaml && (ext === ".yml") ) files.push(name);
+    if ( yaml && (ext === ".yml" || ext === ".yaml") ) files.push(name);
     else if ( !yaml && (ext === ".json") ) files.push(name);
   }
   return files;

--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -307,7 +307,7 @@ async function compactClassicLevel(db) {
  * @returns {Promise<void>}
  */
 export async function extractPack(src, dest, {
-  nedb=false, yaml=false, log=false, documentType, collection, transformEntry, transformName
+  nedb=false, yaml=false, yamlOptions={}, log=false, documentType, collection, transformEntry, transformName
 }={}) {
   if ( nedb && (path.extname(src) !== ".db") ) {
     throw new Error("The nedb option was passed to extractPacks, but the target pack does not have a .db extension.");
@@ -318,8 +318,8 @@ export async function extractPack(src, dest, {
   }
   // Create the output directory if it doesn't exist already.
   fs.mkdirSync(dest, { recursive: true });
-  if ( nedb ) return extractNedb(src, dest, { yaml, log, collection, transformEntry, transformName });
-  return extractClassicLevel(src, dest, { yaml, log, transformEntry, transformName });
+  if ( nedb ) return extractNedb(src, dest, { yaml, yamlOptions, log, collection, transformEntry, transformName });
+  return extractClassicLevel(src, dest, { yaml, log, yamlOptions, transformEntry, transformName });
 }
 
 /* -------------------------------------------- */
@@ -331,7 +331,7 @@ export async function extractPack(src, dest, {
  * @param {Partial<ExtractOptions>} [options]
  * @returns {Promise<void>}
  */
-async function extractNedb(pack, dest, { yaml: asYaml, log, collection, transformEntry, transformName }={}) {
+async function extractNedb(pack, dest, { yaml: asYaml, yamlOptions, log, collection, transformEntry, transformName }={}) {
   // Load the NeDB file.
   const db = new Datastore({ filename: pack, autoload: true });
 
@@ -353,7 +353,7 @@ async function extractNedb(pack, dest, { yaml: asYaml, log, collection, transfor
     }
     const filename = path.join(dest, name);
     fs.mkdirSync(path.dirname(filename), { recursive: true });
-    fs.writeFileSync(filename, asYaml ? yaml.dump(doc) : JSON.stringify(doc, null, 2) + "\n");
+    fs.writeFileSync(filename, asYaml ? yaml.dump(doc, yamlOptions) : JSON.stringify(doc, null, 2) + "\n");
     if ( log ) console.log(`Wrote ${chalk.blue(name)}`);
   }
 }
@@ -367,7 +367,7 @@ async function extractNedb(pack, dest, { yaml: asYaml, log, collection, transfor
  * @param {Partial<ExtractOptions>} [options]
  * @returns {Promise<void>}
  */
-async function extractClassicLevel(pack, dest, { yaml: asYaml, log, transformEntry, transformName }) {
+async function extractClassicLevel(pack, dest, { yaml: asYaml, yamlOptions, log, transformEntry, transformName }) {
   // Load the directory as a ClassicLevel DB.
   const db = new ClassicLevel(pack, { keyEncoding: "utf8", valueEncoding: "json" });
 
@@ -393,7 +393,7 @@ async function extractClassicLevel(pack, dest, { yaml: asYaml, log, transformEnt
     }
     const filename = path.join(dest, name);
     fs.mkdirSync(path.dirname(filename), { recursive: true });
-    fs.writeFileSync(filename, asYaml ? yaml.dump(doc) : JSON.stringify(doc, null, 2) + "\n");
+    fs.writeFileSync(filename, asYaml ? yaml.dump(doc, yamlOptions) : JSON.stringify(doc, null, 2) + "\n");
     if ( log ) console.log(`Wrote ${chalk.blue(name)}`);
   }
 


### PR DESCRIPTION
### Change 1

Add ability for YAML files to end with both `.yaml` and `.yml`

At present if you use the `extractPack` API function with a custom `transformName` function that uses `.yaml` as the extension for the output files `compilePack` will not read any of the YAML files.

As both `.yaml` and `.yml` are both valid extensions for YAML files this PR makes sure both are read when using `compilePack`.

### Change 2

Add ability to pass options to `yaml.dump`

Having the ability to pass options to [yaml.dump](https://github.com/nodeca/js-yaml#dump-object---options-) in the `extract*` functions allows API users to have more control of the output files to conform to their project's needs eg: using `sortKeys` or changing the indentation.