### PR TITLE
Add --config command line flag

### DIFF
--- a/config.mjs
+++ b/config.mjs
@@ -104,4 +104,20 @@ export default class Config {
   #writeConfig() {
     fs.writeFileSync(this.configPath, yaml.dump(this.#config));
   }
+
+  /* -------------------------------------------- */
+
+  /**
+   * Load a local configuration file
+   * @param {string} configFile  The path to the config file
+   */
+  loadLocalConf(configFile) {
+    if ( !fs.existsSync(configFile) ) return;
+    /** @type {Record<string, any>} */
+    const conf = yaml.load(fs.readFileSync(configFile, "utf8"));
+    this.configPath = configFile;
+    for ( let key of Object.keys(conf) ) {
+      this.#config[key] = conf[key];
+    }
+  }
 }

--- a/fvtt.mjs
+++ b/fvtt.mjs
@@ -5,9 +5,14 @@ import { hideBin } from "yargs/helpers";
 import { getCommand as configureCommand } from "./commands/configuration.mjs";
 import { getCommand as packageCommand } from "./commands/package.mjs";
 import { getCommand as launchCommand } from "./commands/launch.mjs";
+import Config from "./config.mjs";
 
 const argv = yargs(hideBin(process.argv))
   .usage("Usage: $0 <command> [options]")
+  .config('config', 'Path to YAML config file', function(configFile) {
+    Config.instance.loadLocalConf(configFile);
+    return Config.instance.getAll();
+  })
   .command(configureCommand())
   .command(packageCommand())
   .command(launchCommand())


### PR DESCRIPTION
When run with --config=/path/to/config.yml, read the configuration
values from that file and merge them into the values from the global
config file. If a configuration value is set using the 'configure set'
command, the value will be written to the local config file specified
instead of the global file.

Ref: #40
