### PR TITLE
Compile Classic Level - Transform Entry First

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare module "foundryvtt-cli" {
    * A mapping of primary document types to collection names.
    * @type {Record<DocumentType, DocumentCollection>}
    */
-  export const TYPE_COLLECTION_MAP = {
+  export const TYPE_COLLECTION_MAP: Record<string, string> = {
     Actor: "actors",
     Adventure: "adventures",
     Cards: "cards",

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,28 @@
-import { CompileOptions } from "./lib/package.mjs";
+import { CompileOptions, ExtractOptions } from "./lib/package.mjs";
 
 declare module "foundryvtt-cli" {
+  /**
+   * A mapping of primary document types to collection names.
+   * @type {Record<DocumentType, DocumentCollection>}
+   */
+  export const TYPE_COLLECTION_MAP = {
+    Actor: "actors",
+    Adventure: "adventures",
+    Cards: "cards",
+    ChatMessage: "messages",
+    Combat: "combats",
+    FogExploration: "fog",
+    Folder: "folders",
+    Item: "items",
+    JournalEntry: "journal",
+    Macro: "macros",
+    Playlist: "playlists",
+    RollTable: "tables",
+    Scene: "scenes",
+    Setting: "settings",
+    User: "users",
+  };
+
   /**
    * Compile source files into a compendium pack.
    * @param {string} src   The directory containing the source files.
@@ -13,5 +35,19 @@ declare module "foundryvtt-cli" {
     src: string,
     dest: string,
     options: CompileOptions
+  ): Promise<void>;
+
+  /**
+   * Extract the contents of a compendium pack into individual source files for each primary Document.
+   * @param {string} src   The source compendium pack. This should be a directory for LevelDB pack, or a .db file for
+   *                       NeDB packs.
+   * @param {string} dest  The directory to write the extracted files into.
+   * @param {ExtractOptions} [options]
+   * @returns {Promise<void>}
+   */
+  export async function extractPack(
+    src: string,
+    dest: string,
+    options: ExtractOptions
   ): Promise<void>;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,17 @@
-import type * as Types from "./lib/package.mjs";
-export { Types };
+import { CompileOptions } from "./lib/package.mjs";
+
+declare module "foundryvtt-cli" {
+  /**
+   * Compile source files into a compendium pack.
+   * @param {string} src   The directory containing the source files.
+   * @param {string} dest  The target compendium pack. This should be a directory for LevelDB packs, or a .db file for
+   *                       NeDB packs.
+   * @param {CompileOptions} [options]
+   * @returns {Promise<void>}
+   */
+  export function compilePack(
+    src: string,
+    dest: string,
+    options: CompileOptions
+  ): Promise<void>;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+import type * as Types from "./lib/package.mjs";
+export { Types };

--- a/index.mjs
+++ b/index.mjs
@@ -1,1 +1,5 @@
-export { compilePack, extractPack } from "./lib/package.mjs";
+export {
+  compilePack,
+  extractPack,
+  TYPE_COLLECTION_MAP,
+} from "./lib/package.mjs";

--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -283,8 +283,8 @@ async function compileClassicLevel(pack, files, { log, transformEntry }={}) {
       const ext = path.extname(file);
       const isYaml = ext === ".yml" || ext === ".yaml";
       const doc = isYaml ? YAML.load(contents) : JSON.parse(contents);
-      const [, collection] = doc._key.split("!");
       if ( await transformEntry?.(doc) === false ) continue;
+      const [, collection] = doc._key.split("!");
       await packDoc(doc, collection);
       if ( log ) console.log(`Packed ${chalk.blue(doc._id)}${chalk.blue(doc.name ? ` (${doc.name})` : "")}`);
     } catch ( err ) {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@foundryvtt/foundryvtt-cli",
   "productName": "Foundry VTT CLI",
   "description": "The Official CLI for Foundry VTT",
-  "version": "0.0.5",
+  "version": "1.0.4",
   "author": {
     "name": "Foundry Gaming LLC",
     "email": "admin@foundryvtt.com",
     "url": "https://foundryvtt.com"
   },
+  "types": "index.d.ts",
   "main": "index.mjs",
   "bin": {
     "fvtt": "fvtt.mjs"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@foundryvtt/foundryvtt-cli",
+  "name": "foundryvtt-cli",
   "productName": "Foundry VTT CLI",
   "description": "The Official CLI for Foundry VTT",
   "version": "1.0.4",


### PR DESCRIPTION
When compiling a classic level database transform the entry before attempting to access the contents. This allows you to not have to put a _key in the files and instead can be generated using transformEntry.