### PR TITLE
[#5] Add option to extract with matching folder structure

### DIFF
--- a/commands/package.mjs
+++ b/commands/package.mjs
@@ -26,6 +26,8 @@ import { compilePack, extractPack, TYPE_COLLECTION_MAP } from "../lib/package.mj
  * @property {boolean} [recursive]                      When packing, recurse down through all directories in the input
  *                                                      directory to find source files.
  * @property {boolean} [clean]                          When unpacking, delete the destination directory first.
+ * @property {boolean} [folders]                        When unpacking, create a directory structure that matches the
+ *                                                      compendium folders.
  */
 
 /**
@@ -122,6 +124,11 @@ export function getCommand() {
       yargs.option("clean", {
         alias: "c",
         describe: "When unpacking, delete the destination directory first.",
+        type: "boolean"
+      });
+
+      yargs.option("folders", {
+        describe: "When unpacking, create a directory structure that matches the compendium folders.",
         type: "boolean"
       });
 

--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -41,17 +41,20 @@ import { ClassicLevel } from "classic-level";
 
 /**
  * @typedef {PackageOptions} ExtractOptions
- * @property {object} [yamlOptions]             Options to pass to yaml.dump when serializing Documents.
- * @property {JSONOptions} [jsonOptions]        Options to pass to JSON.stringify when serializing Documents.
- * @property {DocumentType} [documentType]      Required only for NeDB packs in order to generate a correct key.
- * @property {boolean} [clean]                  Delete the destination directory before unpacking.
- * @property {DocumentCollection} [collection]  Required only for NeDB packs in order to generate a correct key. Can be
- *                                              used instead of documentType if known.
- * @property {NameTransformer} [transformName]  A function that is used to generate a filename for the extracted
- *                                              Document. If used, the generated name must include the appropriate file
- *                                              extension. The generated name will be resolved against the root path
- *                                              provided to the operation, and the entry will be written to that
- *                                              resolved location.
+ * @property {object} [yamlOptions]                   Options to pass to yaml.dump when serializing Documents.
+ * @property {JSONOptions} [jsonOptions]              Options to pass to JSON.stringify when serializing Documents.
+ * @property {DocumentType} [documentType]            Required only for NeDB packs in order to generate a correct key.
+ * @property {boolean} [clean]                        Delete the destination directory before unpacking.
+ * @property {boolean} [folders]                      Create a directory structure that matches the compendium folders.
+ * @property {DocumentCollection} [collection]        Required only for NeDB packs in order to generate a correct key.
+ *                                                    Can be used instead of documentType if known.
+ * @property {NameTransformer} [transformName]        A function that is used to generate a filename for the extracted
+ *                                                    Document. If used, the generated name must include the appropriate
+ *                                                    file extension. The generated name will be resolved against the
+ *                                                    root path provided to the operation, and the entry will be written
+ *                                                    to that resolved location.
+ * @property {NameTransformer} [transformFolderName]  A function used to generate a filename for an extracted folder
+ *                                                    when the folders option is enabled.
  */
 
 /**
@@ -77,6 +80,7 @@ import { ClassicLevel } from "classic-level";
 /**
  * @callback NameTransformer
  * @param {object} entry            The entry data.
+ * @param {string} [folder]         Folder path if this entry is in a folder and the folders option is enabled.
  * @returns {Promise<string|void>}  If a string is returned, it is used as the filename that the entry will be written
  *                                  to.
  */
@@ -339,8 +343,8 @@ async function compactClassicLevel(db) {
  * @returns {Promise<void>}
  */
 export async function extractPack(src, dest, {
-  nedb=false, yaml=false, yamlOptions={}, jsonOptions={}, log=false, documentType, collection, clean, transformEntry,
-  transformName
+  nedb=false, yaml=false, yamlOptions={}, jsonOptions={}, log=false, documentType, collection, clean, folders,
+  transformEntry, transformName, transformFolderName
 }={}) {
   if ( nedb && (path.extname(src) !== ".db") ) {
     throw new Error("The nedb option was passed to extractPacks, but the target pack does not have a .db extension.");
@@ -355,7 +359,9 @@ export async function extractPack(src, dest, {
   if ( nedb ) {
     return extractNedb(src, dest, { yaml, yamlOptions, jsonOptions, log, collection, transformEntry, transformName });
   }
-  return extractClassicLevel(src, dest, { yaml, log, yamlOptions, jsonOptions, transformEntry, transformName });
+  return extractClassicLevel(src, dest, {
+    yaml, log, yamlOptions, jsonOptions, folders, transformEntry, transformName, transformFolderName
+  });
 }
 
 /* -------------------------------------------- */
@@ -405,10 +411,29 @@ async function extractNedb(pack, dest, {
  * @returns {Promise<void>}
  */
 async function extractClassicLevel(pack, dest, {
-  yaml, yamlOptions, jsonOptions, log, transformEntry, transformName
+  yaml, yamlOptions, jsonOptions, log, folders, transformEntry, transformName, transformFolderName
 }) {
   // Load the directory as a ClassicLevel DB.
   const db = new ClassicLevel(pack, { keyEncoding: "utf8", valueEncoding: "json" });
+
+  // Build up the folder structure
+  if ( folders ) {
+    folders = new Map();
+    for await ( const [key, doc] of db.iterator() ) {
+      if ( !key.startsWith("!folders") ) continue;
+      let name = await transformFolderName?.(doc);
+      if ( !name ) name = doc.name ? `${getSafeFilename(doc.name)}_${doc._id}` : key;
+      folders.set(doc._id, { name, folder: doc.folder });
+    }
+    for ( const folder of folders.values() ) {
+      let parent = folders.get(folder.folder);
+      folder.path = folder.name;
+      while ( parent ) {
+        folder.path = path.join(parent.name, folder.path);
+        parent = folders.get(parent.folder);
+      }
+    }
+  }
 
   const unpackDoc = applyHierarchy(async (doc, collection, { sublevelPrefix, idPrefix }={}) => {
     const sublevel = keyJoin(sublevelPrefix, collection);
@@ -426,9 +451,16 @@ async function extractClassicLevel(pack, dest, {
     if ( collection.includes(".") ) continue; // This is not a primary document, skip it.
     await unpackDoc(doc, collection);
     if ( await transformEntry?.(doc) === false ) continue;
-    let name = await transformName?.(doc);
+    const folder = folders.get(doc.folder)?.path;
+    let name = await transformName?.(doc, folder);
     if ( !name ) {
-      name = `${doc.name ? `${getSafeFilename(doc.name)}_${id}` : key}.${yaml ? "yml" : "json"}`;
+      if ( key.startsWith("!folders") && folders.has(doc._id) ) {
+        const folder = folders.get(doc._id);
+        name = path.join(folder.name, `_Folder.${yaml ? "yml" : "json"}`);
+      } else {
+        name = `${doc.name ? `${getSafeFilename(doc.name)}_${id}` : key}.${yaml ? "yml" : "json"}`;
+      }
+      if ( folder ) name = path.join(folder, name);
     }
     const filename = path.join(dest, name);
     serializeDocument(doc, filename, { yaml, yamlOptions, jsonOptions });


### PR DESCRIPTION
Adds the `folders` option to extraction that places extracted documents into folders matching the folders in the original compendium. The folder data itself is added to `_Folder.json/yml` within the created folder.

Adds a `transformFolderName` option when programmatically calling `extractPack` that allows for renaming the folder that will be created. The normal `transformName` callback also gets a second parameter with the containing folder name.

Closes foundryvtt/foundryvtt-cli#5