### PR TITLE
Fixing so that nodejs install version can be lauched with fvtt launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Improvements
  - (Jeff Hitchcock) Added the `--folders` command-line flag, and corresponding `folders` parameter to `extractPack`. When used, this option writes the pack's entries to a directory structure matching the pack's internal Folder document structure.
 
+### Fixes
+ - (Jakob Törmä) Fixed launch command assuming electron directory structure.
+
 ## 1.0.4
 
 ### Improvements

--- a/commands/launch.mjs
+++ b/commands/launch.mjs
@@ -73,19 +73,12 @@ export function getCommand() {
       }
 
       // Figure out if we are running the fvtt application or nodejs version
-      let fvttPath = path.normalize(path.join(installPath, "resources", "app", "main.js")); 
-      try {
-        await fs.promises.stat(fvttPath)
-      } catch (error) {
-        // try to use the nodejs path instead
-        fvttPath = path.normalize(path.join(installPath, "main.js"));
-      }
+      const electronPath = path.normalize(path.join(installPath, "resources", "app", "main.js"));
+      const nodePath = path.normalize(path.join(installPath, "main.js"));
+      const fvttPath = fs.existsSync(electronPath) ? electronPath : nodePath;
 
-      // If we still don't have access to the main.js file then error out
-      try {
-        await fs.promises.stat(fvttPath);
-      } catch (error) {
-        console.error("Unable to find the main.js file under the installPath: %s\n Error: %s", installPath, error)
+      if ( !fs.existsSync(fvttPath) ) {
+        console.error("Unable to find a valid launch path at '%s' or '%s'.", nodePath, electronPath);
         process.exitCode = 1;
         return;
       }


### PR DESCRIPTION
Suggested fix for #63.
There are a few ways of doing this, but this is at least a start on this topic