### PR TITLE
[#46] Extract adventure embedded documents into folders by type

### DIFF
--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -486,22 +486,10 @@ async function extractClassicLevel(pack, dest, {
   const db = new ClassicLevel(pack, { keyEncoding: "utf8", valueEncoding: "json", createIfMissing: false });
 
   // Build up the folder structure
-  const folderMap = new Map();
+  let folderMap = new Map();
   if ( folders ) {
-    for await ( const [key, doc] of db.iterator() ) {
-      if ( !key.startsWith("!folders") ) continue;
-      let name = await transformFolderName?.(doc);
-      if ( !name ) name = doc.name ? `${getSafeFilename(doc.name)}_${doc._id}` : key;
-      folderMap.set(doc._id, { name, folder: doc.folder });
-    }
-    for ( const folder of folderMap.values() ) {
-      let parent = folderMap.get(folder.folder);
-      folder.path = folder.name;
-      while ( parent ) {
-        folder.path = path.join(parent.name, folder.path);
-        parent = folderMap.get(parent.folder);
-      }
-    }
+    const keys = (await db.keys().all()).filter(k => k.startsWith("!folders"));
+    folderMap = await buildFolderMap(await db.getMany(keys), { transformFolderName });
   }
 
   const unpackDoc = applyHierarchy(async (doc, collection, { sublevelPrefix, idPrefix }={}) => {
@@ -556,7 +544,7 @@ async function extractClassicLevel(pack, dest, {
  * @param {Partial<ExtractOptions>} [extractOptions]  Options to configure serialization behavior.
  */
 async function extractAdventure(doc, dest, { folderMap }={}, {
-  yaml, yamlOptions, jsonOptions, log, folders, transformEntry, transformName
+  yaml, yamlOptions, jsonOptions, log, folders, transformEntry, transformName, transformFolderName
 }={}) {
   let adventureFolder;
 
@@ -572,18 +560,29 @@ async function extractAdventure(doc, dest, { folderMap }={}, {
       if ( folder ) name = path.join(folder, name);
     }
   }
+  const context = { adventure: { doc, path: name } };
+
+  // Build up the folder structure
+  const embeddedFolderMap = folders
+    ? await buildFolderMap(doc.folders ?? [], { groupByType: true, transformFolderName })
+    : new Map();
 
   // Write all documents contained in the adventure
-  const context = { adventure: { doc, path: name } };
   for ( const embeddedCollectionName of ADVENTURE_DOCS ) {
     const paths = [];
     for ( const embeddedDoc of doc[embeddedCollectionName] ?? [] ) {
       if ( await transformEntry?.(embeddedDoc, context) === false ) continue;
-      let embeddedName = await transformName?.(embeddedDoc, context);
+      let embeddedFolder = path.join(adventureFolder ?? "", embeddedFolderMap.get(embeddedDoc.folder)?.path ?? "");
+      let embeddedName = await transformName?.(embeddedDoc, { ...context, folder: embeddedFolder });
       if ( !embeddedName ) {
         const { name, _id: id } = embeddedDoc;
-        embeddedName = `${name ? `${getSafeFilename(name)}_${id}` : doc._id}.${yaml ? "yml" : "json"}`;
-        if ( adventureFolder ) embeddedName = path.join(adventureFolder, embeddedName);
+        if ( (embeddedCollectionName === "folders") && embeddedFolderMap.has(embeddedDoc._id) ) {
+          embeddedFolder = adventureFolder;
+          embeddedName = path.join(embeddedFolderMap.get(embeddedDoc._id).path, `_Folder.${yaml ? "yml" : "json"}`);
+        } else {
+          embeddedName = `${name ? `${getSafeFilename(name)}_${id}` : doc._id}.${yaml ? "yml" : "json"}`;
+        }
+        if ( embeddedFolder ) embeddedName = path.join(embeddedFolder, embeddedName);
       }
       const filename = path.join(dest, embeddedName);
       paths.push(path.basename(embeddedName));
@@ -620,6 +619,35 @@ function applyHierarchy(fn) {
     }
   };
   return apply;
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Build up the folder structure used to extract files.
+ * @param {object[]} folders                               Folders to process.
+ * @param {object} [options={}]
+ * @param {boolean} [options.groupByType=false]            Should folders be in sub-folders based on document type?
+ * @param {NameTransformer} [options.transformFolderName]  Name transformer.
+ * @returns {Map<string, string>}                          Mapping of folder IDs to paths.
+ */
+async function buildFolderMap(folders, { groupByType=false, transformFolderName }={}) {
+  const folderMap = new Map();
+  for await ( const doc of folders ) {
+    let name = await transformFolderName?.(doc);
+    if ( !name ) name = doc.name ? `${getSafeFilename(doc.name)}_${doc._id}` : doc._id;
+    folderMap.set(doc._id, { name, folder: doc.folder, type: doc.type });
+  }
+  for ( const folder of folderMap.values() ) {
+    let parent = folderMap.get(folder.folder);
+    folder.path = folder.name;
+    while ( parent ) {
+      folder.path = path.join(parent.name, folder.path);
+      parent = folderMap.get(parent.folder);
+    }
+    if ( groupByType ) folder.path = path.join(folder.type, folder.path);
+  }
+  return folderMap;
 }
 
 /* -------------------------------------------- */


### PR DESCRIPTION
Rather than extracting all of the sub-documents within an adventure into a single folder when the `extractAdventures` and `folders` options are used together, this will extract them into another folder hierarchy based on the document type with folders beneath it.

```
// Current
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/_Adventure.yml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/Folder_Tp23qnV6eCiSlx8T.yml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/Item_TZggpdbOYqOCG7mY.yml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/RollTable_RMi9efrW9ouHVLI2.kml

// New Behavior
_source/Folder_Tp23qnV6eCiSlx8T/_Folder.yml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/_Adventure.yml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/Item/Item_TZggpdbOYqOCG7mY.yml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/RollTable/Folder_Tp23qnV6eCiSlx8T/_Folder.kml
_source/Folder_Tp23qnV6eCiSlx8T/Adventure_feW3xUv1IBq8u3Ve/RollTable/Folder_Tp23qnV6eCiSlx8T/RollTable_RMi9efrW9ouHVLI2.kml
```