### PR TITLE
[#69] Add item type to extracted adventure document names

### DIFF
--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -202,6 +202,12 @@ export const TYPE_COLLECTION_MAP = {
   User: "users"
 };
 
+/**
+ * A mapping of collection names to primary document types.
+ * @type {Record<DocumentCollection, DocumentType>}
+ */
+export const COLLECTION_TYPE_MAP = Object.fromEntries(Object.entries(TYPE_COLLECTION_MAP).map(([k, v]) => [v, k]));
+
 /* -------------------------------------------- */
 /*  Compiling                                   */
 /* -------------------------------------------- */
@@ -571,6 +577,7 @@ async function extractAdventure(doc, dest, { folderMap }={}, {
   // Write all documents contained in the adventure
   for ( const embeddedCollectionName of ADVENTURE_DOCS ) {
     const paths = [];
+    const typeSuffix = folders ? "" : `_${COLLECTION_TYPE_MAP[embeddedCollectionName]}`;
     for ( const embeddedDoc of doc[embeddedCollectionName] ?? [] ) {
       if ( await transformEntry?.(embeddedDoc, context) === false ) continue;
       let embeddedFolder = path.join(adventureFolder ?? "", embeddedFolderMap.get(embeddedDoc.folder)?.path ?? "");
@@ -581,7 +588,7 @@ async function extractAdventure(doc, dest, { folderMap }={}, {
           embeddedFolder = adventureFolder;
           embeddedName = path.join(embeddedFolderMap.get(embeddedDoc._id).path, `_Folder.${yaml ? "yml" : "json"}`);
         } else {
-          embeddedName = `${name ? `${getSafeFilename(name)}_${id}` : doc._id}.${yaml ? "yml" : "json"}`;
+          embeddedName = `${name ? `${getSafeFilename(name)}${typeSuffix}_${id}` : doc._id}.${yaml ? "yml" : "json"}`;
         }
         if ( embeddedFolder ) embeddedName = path.join(embeddedFolder, embeddedName);
       }


### PR DESCRIPTION
When unpacking using the `expandAdventures` option but not the `folders` option, this appends the item type to the name to prevent conflicts caused by two documents of different types that share the same name and ID. This does not make the change when the `folders` option is used because documents of different types are split into their own folders so there is no conflict risk.

This causes the file names of extracted documents to change:
```
// Original
Aarakocra_toaAarakocra0000.yml

// New
Aarakocra_Actor_toaAarakocra0000.yml
```

Closes #69