### PR TITLE
Add pre-write transformation

### DIFF
--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -64,6 +64,7 @@ import { ClassicLevel } from "classic-level";
  *                                                    to that resolved location.
  * @property {NameTransformer} [transformFolderName]  A function used to generate a filename for an extracted folder
  *                                                    when the folders option is enabled.
+ * @property {SerializationTransformer} [transformSerialized] A function used to transform serialized data before writing.
  */
 
 /**
@@ -99,6 +100,14 @@ import { ClassicLevel } from "classic-level";
  * @param {TransformerContext} [context]      Optional context information for the document being transformed.
  * @returns {Promise<string|void>}            If a string is returned, it is used as the filename that the entry will
  *                                            be written to.
+ */
+
+/**
+ * @callback SerializationTransformer
+ * @param {string} serialized                 Serialized data
+ * @param {object} context                    Additional context
+ * @param {string} context.filename           Name of the file being transformed
+ * @param {boolean} context.yaml              Whether this is YAML or JSON
  */
 
 /**
@@ -440,7 +449,7 @@ async function compactClassicLevel(db) {
  */
 export async function extractPack(src, dest, {
   nedb=false, yaml=false, yamlOptions={}, jsonOptions={}, log=false, documentType, collection, clean, folders,
-  expandAdventures, omitVolatile, transformEntry, transformName, transformFolderName
+  expandAdventures, omitVolatile, transformEntry, transformName, transformSerialized, transformFolderName
 }={}) {
   if ( nedb && (path.extname(src) !== ".db") ) {
     throw new Error("The nedb option was passed to extractPacks, but the target pack does not have a .db extension.");
@@ -457,12 +466,12 @@ export async function extractPack(src, dest, {
   try {
     if ( nedb ) {
       await extractNedb(src, tmp, {
-        yaml, yamlOptions, jsonOptions, omitVolatile, log, collection, transformEntry, transformName, existing: dest
+        yaml, yamlOptions, jsonOptions, omitVolatile, log, collection, transformEntry, transformName, transformSerialized, existing: dest
       });
     }
     await extractClassicLevel(src, tmp, {
       yaml, log, yamlOptions, jsonOptions, folders, expandAdventures, omitVolatile, transformEntry, transformName,
-      transformFolderName, existing: dest
+      transformSerialized, transformFolderName, existing: dest
     });
     if ( clean ) fs.rmSync(dest, { force: true, recursive: true, maxRetries: 10 });
     fs.cpSync(tmp, dest, { force: true, recursive: true });
@@ -482,7 +491,7 @@ export async function extractPack(src, dest, {
  * @returns {Promise<void>}
  */
 async function extractNedb(pack, dest, {
-  yaml, yamlOptions, jsonOptions, omitVolatile, log, collection, transformEntry, transformName, existing
+  yaml, yamlOptions, jsonOptions, omitVolatile, log, collection, transformEntry, transformName, transformSerialized, existing
 }={}) {
   // Load the NeDB file.
   const db = new Datastore({ filename: pack, autoload: true });
@@ -504,8 +513,8 @@ async function extractNedb(pack, dest, {
       name = `${doc.name ? `${getSafeFilename(doc.name)}_${doc._id}` : doc._id}.${yaml ? "yml" : "json"}`;
     }
     const filename = path.join(dest, name);
-    serializeDocument(checkVolatile(doc, name, { collection, omitVolatile, existing, yaml }), filename, {
-      yaml, yamlOptions, jsonOptions
+    await serializeDocument(checkVolatile(doc, name, { collection, omitVolatile, existing, yaml }), filename, {
+      yaml, yamlOptions, jsonOptions, transformSerialized, filename: name
     });
     if ( log ) console.log(`Wrote ${chalk.blue(name)}`);
   }
@@ -522,7 +531,7 @@ async function extractNedb(pack, dest, {
  * @returns {Promise<void>}
  */
 async function extractClassicLevel(pack, dest, {
-  yaml, yamlOptions, jsonOptions, log, folders, expandAdventures, omitVolatile, transformEntry, transformName,
+  yaml, yamlOptions, jsonOptions, log, folders, expandAdventures, omitVolatile, transformEntry, transformName, transformSerialized,
   transformFolderName, existing
 }={}) {
   // Load the directory as a ClassicLevel DB.
@@ -553,7 +562,7 @@ async function extractClassicLevel(pack, dest, {
     if ( await transformEntry?.(doc) === false ) continue;
     if ( key.startsWith("!adventures") && expandAdventures ) {
       await extractAdventure(doc, dest, { folderMap }, {
-        yaml, yamlOptions, jsonOptions, log, folders, omitVolatile, transformEntry, transformName, existing
+        yaml, yamlOptions, jsonOptions, log, folders, omitVolatile, transformEntry, transformName, transformSerialized, existing
       });
       continue;
     }
@@ -569,8 +578,8 @@ async function extractClassicLevel(pack, dest, {
       if ( folder ) name = path.join(folder, name);
     }
     const filename = path.join(dest, name);
-    serializeDocument(checkVolatile(doc, name, { collection, omitVolatile, existing, yaml }), filename, {
-      yaml, yamlOptions, jsonOptions
+    await serializeDocument(checkVolatile(doc, name, { collection, omitVolatile, existing, yaml }), filename, {
+      yaml, yamlOptions, jsonOptions, transformSerialized, filename: name
     });
     if ( log ) console.log(`Wrote ${chalk.blue(name)}`);
   }
@@ -590,7 +599,7 @@ async function extractClassicLevel(pack, dest, {
  * @param {string} [extractOptions.existing]          The location of existing serialized Documents.
  */
 async function extractAdventure(doc, dest, { folderMap }={}, {
-  yaml, yamlOptions, jsonOptions, log, folders, omitVolatile, transformEntry, transformName, transformFolderName, existing
+  yaml, yamlOptions, jsonOptions, log, folders, omitVolatile, transformEntry, transformName, transformSerialized, transformFolderName, existing
 }={}) {
   let adventureFolder;
 
@@ -635,11 +644,11 @@ async function extractAdventure(doc, dest, { folderMap }={}, {
       const embeddedPath =
         adventureFolder ? path.relative(adventureFolder, embeddedName) : path.basename(embeddedName);
       paths.push(path.posix.join(...embeddedPath.split(path.sep)));
-      serializeDocument(checkVolatile(embeddedDoc, embeddedName, {
+      await serializeDocument(checkVolatile(embeddedDoc, embeddedName, {
         omitVolatile, existing, yaml,
         collection: embeddedCollectionName
       }), filename, {
-        yaml, yamlOptions, jsonOptions
+        yaml, yamlOptions, jsonOptions, transformSerialized, filename: embeddedName
       });
       if ( log ) console.log(`Wrote ${chalk.blue(embeddedName)}`);
     }
@@ -648,8 +657,8 @@ async function extractAdventure(doc, dest, { folderMap }={}, {
 
   // Write the adventure itself
   const filename = path.join(dest, name);
-  serializeDocument(checkVolatile(doc, name, { omitVolatile, existing, yaml }), filename, {
-    yaml, yamlOptions, jsonOptions
+  await serializeDocument(checkVolatile(doc, name, { omitVolatile, existing, yaml }), filename, {
+    yaml, yamlOptions, jsonOptions, transformSerialized, filename: name
   });
   if ( log ) console.log(`Wrote ${chalk.blue(name)}`);
 }
@@ -786,7 +795,7 @@ function findSourceFiles(root, { yaml=false, recursive=false }={}) {
  * @param {string} filename                    The filename to write it to.
  * @param {Partial<ExtractOptions>} [options]  Options to configure serialization behavior.
  */
-function serializeDocument(doc, filename, { yaml, yamlOptions, jsonOptions }={}) {
+async function serializeDocument(doc, filename, { yaml, yamlOptions, jsonOptions, transformSerialized, filename: destName }={}) {
   fs.mkdirSync(path.dirname(filename), { recursive: true });
   let serialized;
   if ( yaml ) serialized = YAML.dump(doc, yamlOptions);
@@ -794,6 +803,11 @@ function serializeDocument(doc, filename, { yaml, yamlOptions, jsonOptions }={})
     const { replacer=null, space=2 } = jsonOptions;
     serialized = JSON.stringify(doc, replacer, space) + "\n";
   }
+
+  if (typeof transformSerialized === "function") {
+    serialized = await transformSerialized(serialized, { yaml, filename: destName });
+  }
+
   fs.writeFileSync(filename, serialized);
 }
 


### PR DESCRIPTION
Implements #56 

Tested with the following transformer:
```js
transformSerialized: async (content, { filename } = {}) => {
  return prettier.format(content, { ...prettierConfig, filepath: filename });
},
```