### PR TITLE
replace js-yaml with yaml

### DIFF
--- a/config.mjs
+++ b/config.mjs
@@ -1,5 +1,5 @@
 import fs from "fs";
-import yaml from "js-yaml";
+import * as yaml from "yaml";
 import path from "path";
 import * as os from "os";
 
@@ -41,8 +41,8 @@ export default class Config {
     this.configPath = path.join(basePath, ".fvttrc.yml");
 
     // Ensure the config file exists
-    if ( !fs.existsSync(this.configPath) ) fs.writeFileSync(this.configPath, yaml.dump({}));
-    this.#config = yaml.load(fs.readFileSync(this.configPath, "utf8"));
+    if ( !fs.existsSync(this.configPath) ) fs.writeFileSync(this.configPath, yaml.stringify({}));
+    this.#config = yaml.parse(fs.readFileSync(this.configPath, "utf8"));
   }
 
   /* -------------------------------------------- */
@@ -102,7 +102,7 @@ export default class Config {
    * Write the configuration to disk
    */
   #writeConfig() {
-    fs.writeFileSync(this.configPath, yaml.dump(this.#config));
+    fs.writeFileSync(this.configPath, yaml.stringify(this.#config));
   }
 
   /* -------------------------------------------- */
@@ -114,7 +114,7 @@ export default class Config {
   loadLocalConf(configFile) {
     if ( !fs.existsSync(configFile) ) return;
     /** @type {Record<string, any>} */
-    const conf = yaml.load(fs.readFileSync(configFile, "utf8"));
+    const conf = yaml.parse(fs.readFileSync(configFile, "utf8"));
     this.configPath = configFile;
     for ( const key of Object.keys(conf) ) this.#config[key] = conf[key];
   }

--- a/lib/package.mjs
+++ b/lib/package.mjs
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import Datastore from "nedb-promises";
 import chalk from "chalk";
-import { default as YAML } from "js-yaml";
+import * as YAML from "yaml";
 import { ClassicLevel } from "classic-level";
 
 /* -------------------------------------------- */
@@ -42,7 +42,7 @@ import { ClassicLevel } from "classic-level";
 
 /**
  * @typedef {PackageOptions} ExtractOptions
- * @property {object} [yamlOptions]                   Options to pass to yaml.dump when serializing Documents.
+ * @property {object} [yamlOptions]                   Options to pass to yaml.stringify when serializing Documents.
  * @property {JSONOptions} [jsonOptions]              Options to pass to JSON.stringify when serializing Documents.
  * @property {DocumentType} [documentType]            Required only for NeDB packs in order to generate a correct key.
  * @property {boolean} [clean]                        Delete the destination directory before unpacking.
@@ -285,7 +285,7 @@ async function compileNedb(pack, files, { log, transformEntry }={}) {
       const contents = fs.readFileSync(file, "utf8");
       const ext = path.extname(file);
       const isYaml = ext === ".yml" || ext === ".yaml";
-      const doc = isYaml ? YAML.load(contents) : JSON.parse(contents);
+      const doc = isYaml ? YAML.parse(contents) : JSON.parse(contents);
       if ( !doc._key ) continue;
       if ( doc._key.startsWith("!adventures") ) await reconstructAdventure(path.dirname(file), doc, {
         transformEntry, log
@@ -345,7 +345,7 @@ async function compileClassicLevel(pack, files, { log, transformEntry }={}) {
       const contents = fs.readFileSync(file, "utf8");
       const ext = path.extname(file);
       const isYaml = ext === ".yml" || ext === ".yaml";
-      const doc = isYaml ? YAML.load(contents) : JSON.parse(contents);
+      const doc = isYaml ? YAML.parse(contents) : JSON.parse(contents);
       if ( !doc._key ) continue;
       if ( doc._key.startsWith("!adventures") ) await reconstructAdventure(path.dirname(file), doc, {
         transformEntry, log
@@ -398,7 +398,7 @@ async function reconstructAdventure(src, doc, { transformEntry, log }={}) {
         }
         const ext = path.extname(file);
         const isYaml = ext === ".yml" || ext === ".yaml";
-        entry = isYaml ? YAML.load(contents) : JSON.parse(contents);
+        entry = isYaml ? YAML.parse(contents) : JSON.parse(contents);
         if ( await transformEntry?.(entry, context) === false ) continue;
       }
       entries.push(entry);
@@ -789,7 +789,14 @@ function findSourceFiles(root, { yaml=false, recursive=false }={}) {
 function serializeDocument(doc, filename, { yaml, yamlOptions, jsonOptions }={}) {
   fs.mkdirSync(path.dirname(filename), { recursive: true });
   let serialized;
-  if ( yaml ) serialized = YAML.dump(doc, yamlOptions);
+  if (yaml) {
+    // Mimic js-yaml format as closely as possible
+    yamlOptions = {
+      singleQuote: true,
+      ...yamlOptions
+    };
+    serialized = YAML.stringify(doc, undefined, yamlOptions);
+  }
   else {
     const { replacer=null, space=2 } = jsonOptions;
     serialized = JSON.stringify(doc, replacer, space) + "\n";
@@ -813,7 +820,7 @@ function serializeDocument(doc, filename, { yaml, yamlOptions, jsonOptions }={})
  */
 function checkVolatile(doc, name, { omitVolatile, existing, yaml, collection }={}) {
   if ( !omitVolatile || !existing || !("_stats" in doc) ) return doc;
-  const parse = yaml ? YAML.load : JSON.parse;
+  const parse = yaml ? YAML.parse : JSON.parse;
   try {
     const base = parse(fs.readFileSync(path.join(existing, name), { encoding: "utf8" }));
     if ( !base || !("_stats" in base) ) return doc;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "chalk": "^5.4.1",
         "classic-level": "^1.4.1",
         "esm": "^3.2.25",
-        "js-yaml": "^4.1.0",
         "mkdirp": "^3.0.1",
         "nedb-promises": "^6.2.3",
+        "yaml": "^2.8.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -280,7 +280,8 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -1312,6 +1313,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1965,6 +1967,18 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "chalk": "^5.4.1",
     "classic-level": "^1.4.1",
     "esm": "^3.2.25",
-    "js-yaml": "^4.1.0",
     "mkdirp": "^3.0.1",
     "nedb-promises": "^6.2.3",
+    "yaml": "^2.8.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Implements #80 

This mimics js-yaml output as closely as possible to reduce output drift and needing to reconfigure things.

Notable flaws:
- Old yaml options obviously do not work (e.g. sortKeys)
  - `yaml`  has features for this, but it is not just a boolean and it is by different name
- `js-yaml` "smartly" used block folding for long strings while `yaml` has no such feature. It uses block folding only if newlines are present.
  - This affects only first two lines of large text blocks so it isn't too terrible.

I'm fine if this PR is thrown away.